### PR TITLE
Upgrade feed plugin to use with saber 0.5.x

### DIFF
--- a/packages/saber-plugin-generate-sitemap/lib/index.js
+++ b/packages/saber-plugin-generate-sitemap/lib/index.js
@@ -51,7 +51,7 @@ exports.apply = (api, options = {}) => {
         posts: posts
       })
       await fs.outputFile(
-        api.resolveCwd(path.join('.saber/public/', options.path)),
+        path.resolve(api.resolveOutDir(), options.path),
         xml,
         'utf8'
       )

--- a/packages/saber-plugin-generate-sitemap/package.json
+++ b/packages/saber-plugin-generate-sitemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saber-plugin-generate-sitemap",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Sitemap generator plugin for Saber.js",
   "author": "Chawye Hsu <h404bi@gmail.com>",
   "homepage": "https://github.com/h404bi/www.h404bi.com#readme",
@@ -16,6 +16,9 @@
   },
   "dependencies": {
     "ejs": "^2.6.1"
+  },
+  "peerDependencies": {
+    "saber": "^0.5.0"
   },
   "keywords": [
     "saber",


### PR DESCRIPTION
The static folder was changed in saber after 0.5.x

An `api.resolveOutDir` can help with it.

refs:
- https://github.com/saberland/saber/blob/1613626/packages/saber-plugin-feed/lib/index.js#L109